### PR TITLE
Autodetect if host is behind a HTTPS proxy

### DIFF
--- a/Libvaloa/Controller/Request.php
+++ b/Libvaloa/Controller/Request.php
@@ -64,7 +64,7 @@ class Request
         $uri = $_SERVER['HTTP_HOST'].$tmp.str_replace(str_replace('index.php', '', $tmp), '/', $_SERVER['REQUEST_URI']);
 
         // http/https autodetect
-        if (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on') {
+        if ((isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on') || $_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https') {
             $prefix = 'https://';
         } else {
             $prefix = 'http://';
@@ -112,6 +112,10 @@ class Request
         if (isset($_SERVER['HTTPS'])) {
             $this->protocol = ($_SERVER['HTTPS']
                 && $_SERVER['HTTPS'] != 'off') ? 'https' : 'http';
+        }
+
+        if ($_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https') {
+            $this->protocol = 'https';
         }
 
         self::$instance = $this;


### PR DESCRIPTION
Detects via HTTP_X_FORWARDED_PROTO header if the host is behind a server that is forwarding to the user as HTTPS.
Works out of the box with Cloudflare and other services.
It's also a good practice to use this header with custom ssl proxy setups, like with nginx.
